### PR TITLE
Provide a default variable for XDG_CACHE_HOME if it's unset

### DIFF
--- a/rofi-emoji-picker
+++ b/rofi-emoji-picker
@@ -1,6 +1,6 @@
 #! /bin/bash
 URL="https://www.unicode.org/Public/emoji/latest/emoji-test.txt"
-FILE="$XDG_CACHE_HOME/rofi-emoji-picker-data.txt"
+FILE="${XDG_CACHE_HOME:=$HOME/.cache}/rofi-emoji-picker-data.txt"
 
 if [ ! -f "$FILE" ]; then
     curl -L "$URL" -o "$FILE"


### PR DESCRIPTION
It's generally considered up to the writers of the software to provide a default value for these variables if they're not set.

Also unsure why the commit is showing changed lines elsewhere, I only changed line 3